### PR TITLE
Add supabase backend example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+SUPABASE_URL=your_supabase_url
+SUPABASE_ANON_KEY=your_supabase_anon_key
+PORT=3000

--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
-# Codex
+# Supabase Login Demo
+
+This demo shows how to implement basic sign up and login flows using [Supabase](https://supabase.com) for authentication. The backend is a small Express server that forwards signup and login requests to Supabase.
+
+## Setup
+
+1. Copy `.env.example` to `.env` and fill in your Supabase project URL and anon key.
+2. Install dependencies with `npm install` (requires Node 18+).
+3. Start the server using `npm start`. The HTML pages will be served on the same port.
+4. Open `http://localhost:3000/index.html` in your browser to sign up or log in.
+
+## Files
+- `index.html` – Home page with links to sign up or log in
+- `signup.html` – Sign up form posting to the `/signup` endpoint
+- `login.html` – Login form posting to the `/login` endpoint
+- `welcome.html` – Landing page after a successful login
+- `server.js` – Express server integrating with Supabase
+- `package.json` – Node.js dependencies
+
+The project does not include Supabase credentials. You must supply them in your own `.env` file.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Home</title>
+</head>
+<body>
+    <h1>Welcome</h1>
+    <p><a href="signup.html">Sign Up</a></p>
+    <p><a href="login.html">Log In</a></p>
+</body>
+</html>

--- a/login.html
+++ b/login.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Log In</title>
+</head>
+<body>
+    <h1>Log In</h1>
+    <form id="loginForm">
+        <label for="email">Email:</label>
+        <input type="email" id="email" required><br>
+        <label for="password">Password:</label>
+        <input type="password" id="password" required><br>
+        <button type="submit">Log In</button>
+    </form>
+    <p>Need an account? <a href="signup.html">Sign up</a></p>
+    <script>
+    document.getElementById('loginForm').addEventListener('submit', async function(e) {
+        e.preventDefault();
+        const email = document.getElementById('email').value;
+        const password = document.getElementById('password').value;
+        const res = await fetch('/login', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ email, password })
+        });
+        const data = await res.json();
+        if (res.ok) {
+            localStorage.setItem('sb_token', data.session.access_token);
+            localStorage.setItem('loggedInUser', data.user.email);
+            window.location.href = 'welcome.html';
+        } else {
+            alert(data.error || 'Invalid credentials');
+        }
+    });
+    </script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "codex-login-demo",
+  "version": "1.0.0",
+  "description": "Example login/signup using Supabase",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "cors": "^2.8.5",
+    "@supabase/supabase-js": "^2.43.1"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,45 @@
+const express = require('express');
+const cors = require('cors');
+const { createClient } = require('@supabase/supabase-js');
+require('dotenv').config();
+
+const app = express();
+const port = process.env.PORT || 3000;
+
+app.use(cors());
+app.use(express.json());
+app.use(express.static(__dirname));
+
+const supabaseUrl = process.env.SUPABASE_URL;
+const supabaseAnonKey = process.env.SUPABASE_ANON_KEY;
+const supabase = createClient(supabaseUrl, supabaseAnonKey);
+
+app.post('/signup', async (req, res) => {
+  const { email, password } = req.body;
+  try {
+    const { data, error } = await supabase.auth.signUp({ email, password });
+    if (error) {
+      return res.status(400).json({ error: error.message });
+    }
+    res.json({ user: data.user });
+  } catch (err) {
+    res.status(500).json({ error: 'Server error' });
+  }
+});
+
+app.post('/login', async (req, res) => {
+  const { email, password } = req.body;
+  try {
+    const { data, error } = await supabase.auth.signInWithPassword({ email, password });
+    if (error) {
+      return res.status(400).json({ error: error.message });
+    }
+    res.json({ session: data.session, user: data.user });
+  } catch (err) {
+    res.status(500).json({ error: 'Server error' });
+  }
+});
+
+app.listen(port, () => {
+  console.log(`Server listening on port ${port}`);
+});

--- a/signup.html
+++ b/signup.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Sign Up</title>
+</head>
+<body>
+    <h1>Create Account</h1>
+    <form id="signupForm">
+        <label for="email">Email:</label>
+        <input type="email" id="email" required><br>
+        <label for="password">Password:</label>
+        <input type="password" id="password" required><br>
+        <button type="submit">Sign Up</button>
+    </form>
+    <p>Already have an account? <a href="login.html">Log in</a></p>
+    <script>
+    document.getElementById('signupForm').addEventListener('submit', async function(e) {
+        e.preventDefault();
+        const email = document.getElementById('email').value;
+        const password = document.getElementById('password').value;
+        const res = await fetch('/signup', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ email, password })
+        });
+        const data = await res.json();
+        if (res.ok) {
+            alert('Account created! You can now log in.');
+            window.location.href = 'login.html';
+        } else {
+            alert(data.error || 'Sign up failed');
+        }
+    });
+    </script>
+</body>
+</html>

--- a/welcome.html
+++ b/welcome.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Welcome</title>
+</head>
+<body>
+    <h1 id="greeting"></h1>
+    <p><a href="login.html" id="logout">Log out</a></p>
+    <script>
+    const user = localStorage.getItem('loggedInUser');
+    if (!user) {
+        window.location.href = 'login.html';
+    } else {
+        document.getElementById('greeting').textContent = 'Hello, ' + user + '!';
+    }
+    document.getElementById('logout').addEventListener('click', function() {
+        localStorage.removeItem('loggedInUser');
+        localStorage.removeItem('sb_token');
+    });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- replace client-only demo with Supabase-backed version
- add Express server that proxies signup and login
- update HTML pages to call the new endpoints
- document setup and configuration in README
- provide `.env.example` and Node dependencies

## Testing
- `npm test` *(fails: Missing script)*
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684a6b1db4a0832eb4b3378ea531b2d3